### PR TITLE
Added support for `align_(pri|alt)` OPcodes

### DIFF
--- a/src/main/java/lysis/BitConverter.java
+++ b/src/main/java/lysis/BitConverter.java
@@ -23,6 +23,15 @@ public class BitConverter {
 		return result;
 	}
 
+	public static int ToInt32LittleEndian(byte[] bytes, int offset) {
+	    int result = (int) bytes[offset + 3] & 0xff;
+	    result |= ((int) bytes[offset + 2] & 0xff) << 8;
+	    result |= ((int) bytes[offset + 1] & 0xff) << 16;
+	    result |= ((int) bytes[offset] & 0xff) << 24;
+	    return result;
+	}
+
+
 	public static long ToUInt32(byte[] bytes, int offset) {
 		long result = (int) bytes[offset] & 0xff;
 		result |= ((int) bytes[offset + 1] & 0xff) << 8;

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -118,6 +118,11 @@ public class MethodParser {
 		return BitConverter.ToUInt32(file_.code().bytes(), (int) pc_ - 4);
 	}
 
+	private int readInt32LittleEndian() {
+	    pc_ += 4;
+	    return BitConverter.ToInt32LittleEndian(file_.code().bytes(), (int) pc_ - 4);
+	}
+
 	private SPOpcode readOp() {
 		return SPOpcode.values()[(int) readUInt32()];
 	}
@@ -227,6 +232,13 @@ public class MethodParser {
 
 		case idxaddr_b:
 			return new LIndexAddress(readInt32());
+
+		case align_pri:
+		case align_alt:
+		{
+			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
+			return new LAlign(trackGlobal(readInt32LittleEndian()), reg);
+		}
 
 		case move_pri:
 		case move_alt: {
@@ -684,13 +696,6 @@ public class MethodParser {
 			readUInt32(); // ident
 			pc_ += num - 8; // skip dbgname
 			return new LDebugBreak();
-		}
-		
-		case align_pri:
-		case align_alt:
-		{
-			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
-			return new LAlign(trackGlobal(readInt32()), reg);
 		}
 
 		default:

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -236,7 +236,7 @@ public class MethodParser {
 		case align_pri:
 		case align_alt:
 		{
-			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
+			Register reg = (op == SPOpcode.align_pri) ? Register.Pri : Register.Alt;
 			return new LAlign(trackGlobal(readInt32LittleEndian()), reg);
 		}
 

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -72,6 +72,7 @@ import lysis.instructions.LUnary;
 import lysis.instructions.LZeroGlobal;
 import lysis.instructions.LZeroLocal;
 import lysis.instructions.SwitchCase;
+import lysis.instructions.LAlign;
 import lysis.lstructure.Function;
 import lysis.lstructure.LBlock;
 import lysis.lstructure.LGraph;
@@ -226,6 +227,13 @@ public class MethodParser {
 
 		case idxaddr_b:
 			return new LIndexAddress(readInt32());
+
+		case align_pri:
+		case align_alt:
+		{
+			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
+			return new LAlign(reg);
+		}
 
 		case move_pri:
 		case move_alt: {
@@ -683,13 +691,6 @@ public class MethodParser {
 			readUInt32(); // ident
 			pc_ += num - 8; // skip dbgname
 			return new LDebugBreak();
-		}
-		
-		case align_pri:
-		case align_alt:
-		{
-			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
-			return new LStackAddress(trackStack(readInt32()), reg);
 		}
 
 		default:

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -684,6 +684,13 @@ public class MethodParser {
 			pc_ += num - 8; // skip dbgname
 			return new LDebugBreak();
 		}
+		
+		case align_pri:
+		case align_alt:
+		{
+			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
+			return new LStackAddress(trackStack(readInt32()), reg);
+		}
 
 		default:
 			throw new Exception("Unrecognized opcode: " + op);

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -72,7 +72,6 @@ import lysis.instructions.LUnary;
 import lysis.instructions.LZeroGlobal;
 import lysis.instructions.LZeroLocal;
 import lysis.instructions.SwitchCase;
-import lysis.instructions.LAlign;
 import lysis.lstructure.Function;
 import lysis.lstructure.LBlock;
 import lysis.lstructure.LGraph;
@@ -227,13 +226,6 @@ public class MethodParser {
 
 		case idxaddr_b:
 			return new LIndexAddress(readInt32());
-
-		case align_pri:
-		case align_alt:
-		{
-			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
-			return new LAlign(reg);
-		}
 
 		case move_pri:
 		case move_alt: {
@@ -691,6 +683,13 @@ public class MethodParser {
 			readUInt32(); // ident
 			pc_ += num - 8; // skip dbgname
 			return new LDebugBreak();
+		}
+		
+		case align_pri:
+		case align_alt:
+		{
+			Register reg = (op == SPOpcode.addr_pri) ? Register.Pri : Register.Alt;
+			return new LAlign(trackGlobal(readInt32()), reg);
 		}
 
 		default:

--- a/src/main/java/lysis/builder/MethodParser.java
+++ b/src/main/java/lysis/builder/MethodParser.java
@@ -72,6 +72,7 @@ import lysis.instructions.LUnary;
 import lysis.instructions.LZeroGlobal;
 import lysis.instructions.LZeroLocal;
 import lysis.instructions.SwitchCase;
+import lysis.instructions.LAlign;
 import lysis.lstructure.Function;
 import lysis.lstructure.LBlock;
 import lysis.lstructure.LGraph;

--- a/src/main/java/lysis/builder/SourceBuilder.java
+++ b/src/main/java/lysis/builder/SourceBuilder.java
@@ -26,6 +26,7 @@ import lysis.lstructure.VariableType;
 import lysis.nodes.NodeBlock;
 import lysis.nodes.NodeList;
 import lysis.nodes.NodeType;
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoolean;
@@ -410,6 +411,10 @@ public class SourceBuilder {
 		case Unary: {
 			return buildUnary((DUnary) node) + "/* ERROR unknown load Unary */";
 		}
+		
+		case Align: {
+			return buildAlign((DAlign) node);
+		}
 
 		default:
 			throw new Exception("unknown load " + node.type());
@@ -418,6 +423,10 @@ public class SourceBuilder {
 
 	private String buildLoad(DLoad load) throws Exception {
 		return buildLoadStoreRef(load.getOperand(0));
+	}
+	
+	private String buildAlign(DAlign alg) throws Exception {
+		return buildLoadStoreRef(alg.getOperand(0));
 	}
 
 	private String buildSysReq(DSysReq sysreq) throws Exception {
@@ -812,6 +821,9 @@ public class SourceBuilder {
 
 		case Label:
 			writeLabel((DLabel) node);
+			break;
+			
+		case Align:
 			break;
 
 		default:

--- a/src/main/java/lysis/instructions/LAlign.java
+++ b/src/main/java/lysis/instructions/LAlign.java
@@ -5,16 +5,16 @@ import java.io.IOException;
 
 import lysis.lstructure.Register;
 
-public class LAlign extends LInstructionReg {
-	
-	private long offset_;
+public class LAlign extends LInstructionRegStack {
+    
+    private long number_;
 
-	public long offset() {
-		return offset_;
-	}
-    public LAlign(long offset, Register reg) {
-		super(reg);
-		offset_ = offset;
+    public long number() {
+        return number_;
+    }
+    public LAlign(long number, Register reg) {
+        super(reg, number);
+        number_ = number;
     }
 
     @Override
@@ -24,7 +24,6 @@ public class LAlign extends LInstructionReg {
 
     @Override
     public void print(DataOutputStream tw) throws IOException {
-        tw.writeBytes("align." + RegisterName(reg()) + ", "
-				+ (reg() == Register.Pri ? RegisterName(Register.Alt) : RegisterName(Register.Pri)) + offset());
+        tw.writeBytes("align." + (reg() == Register.Pri ? RegisterName(Register.Pri) : RegisterName(Register.Alt)) + number());
     }
 }

--- a/src/main/java/lysis/instructions/LAlign.java
+++ b/src/main/java/lysis/instructions/LAlign.java
@@ -1,0 +1,24 @@
+package lysis.instructions;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import lysis.lstructure.Register;
+
+public class LAlign extends LInstructionReg {
+
+    public LAlign(Register reg) {
+        super(reg);
+    }
+
+    @Override
+    public Opcode op() {
+        return Opcode.Align;
+    }
+
+    @Override
+    public void print(DataOutputStream tw) throws IOException {
+        tw.writeBytes("align." + RegisterName(reg()) + ", "
+				+ (reg() == Register.Pri ? RegisterName(Register.Alt) : RegisterName(Register.Pri)));
+    }
+}

--- a/src/main/java/lysis/instructions/LAlign.java
+++ b/src/main/java/lysis/instructions/LAlign.java
@@ -6,9 +6,15 @@ import java.io.IOException;
 import lysis.lstructure.Register;
 
 public class LAlign extends LInstructionReg {
+	
+	private long offset_;
 
-    public LAlign(Register reg) {
-        super(reg);
+	public long offset() {
+		return offset_;
+	}
+    public LAlign(long offset, Register reg) {
+		super(reg);
+		offset_ = offset;
     }
 
     @Override
@@ -19,6 +25,6 @@ public class LAlign extends LInstructionReg {
     @Override
     public void print(DataOutputStream tw) throws IOException {
         tw.writeBytes("align." + RegisterName(reg()) + ", "
-				+ (reg() == Register.Pri ? RegisterName(Register.Alt) : RegisterName(Register.Pri)));
+				+ (reg() == Register.Pri ? RegisterName(Register.Alt) : RegisterName(Register.Pri)) + offset());
     }
 }

--- a/src/main/java/lysis/instructions/Opcode.java
+++ b/src/main/java/lysis/instructions/Opcode.java
@@ -1,5 +1,5 @@
 package lysis.instructions;
 
 public enum Opcode {
-	LoadLocal, StoreLocal, LoadLocalRef, StoreLocalRef, Load, Constant, StackAddress, Store, IndexAddress, Move, PushReg, PushConstant, Pop, Stack, Return, Jump, JumpCondition, AddConstant, MulConstant, ZeroGlobal, IncGlobal, DecGlobal, IncLocal, DecLocal, IncI, IncReg, DecI, DecReg, Fill, Bounds, SysReq, Swap, PushStackAddress, DebugBreak, Goto, PushLocal, Exchange, Binary, ShiftLeftConstant, PushGlobal, StoreGlobal, LoadGlobal, Call, EqualConstant, LoadIndex, Unary, StoreGlobalConstant, StoreLocalConstant, ZeroLocal, Heap, MemCopy, Switch, GenArray, StackAdjust, LoadCtrl, StoreCtrl, InitArray
+	LoadLocal, StoreLocal, LoadLocalRef, StoreLocalRef, Load, Constant, StackAddress, Store, IndexAddress, Move, PushReg, PushConstant, Pop, Stack, Return, Jump, JumpCondition, AddConstant, MulConstant, ZeroGlobal, IncGlobal, DecGlobal, IncLocal, DecLocal, IncI, IncReg, DecI, DecReg, Fill, Bounds, SysReq, Swap, PushStackAddress, DebugBreak, Goto, PushLocal, Exchange, Binary, ShiftLeftConstant, PushGlobal, StoreGlobal, LoadGlobal, Call, EqualConstant, LoadIndex, Unary, StoreGlobalConstant, StoreLocalConstant, ZeroLocal, Heap, MemCopy, Switch, GenArray, StackAdjust, LoadCtrl, StoreCtrl, InitArray, Align
 }

--- a/src/main/java/lysis/nodes/NodeBuilder.java
+++ b/src/main/java/lysis/nodes/NodeBuilder.java
@@ -58,6 +58,7 @@ import lysis.instructions.LSysReq;
 import lysis.instructions.LUnary;
 import lysis.instructions.LZeroGlobal;
 import lysis.instructions.LZeroLocal;
+import lysis.instructions.LAlign;
 import lysis.instructions.Opcode;
 import lysis.lstructure.Function;
 import lysis.lstructure.LBlock;
@@ -789,6 +790,15 @@ public class NodeBuilder {
 						block.stack().pop();
 				}
 				block.add(new DLabel(ins.pc()));
+				break;
+			}
+			
+			case Align: {
+				LAlign ins = (LAlign) uins;
+				if (ins.reg() == Register.Pri)
+					block.stack().set(Register.Pri, block.stack().alt());
+				else
+					block.stack().set(Register.Alt, block.stack().pri());
 				break;
 			}
 

--- a/src/main/java/lysis/nodes/NodeBuilder.java
+++ b/src/main/java/lysis/nodes/NodeBuilder.java
@@ -66,6 +66,7 @@ import lysis.lstructure.LGraph;
 import lysis.lstructure.Register;
 import lysis.lstructure.Scope;
 import lysis.lstructure.Variable;
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoundsCheck;
@@ -384,6 +385,15 @@ public class NodeBuilder {
 				LIndexAddress ins = (LIndexAddress) uins;
 				DArrayRef node = new DArrayRef(block.stack().alt(), block.stack().pri(), ins.shift());
 				block.stack().set(Register.Pri, node);
+				block.add(node);
+				break;
+			}
+			
+			case Align: {
+				LAlign ins = (LAlign) uins;
+				DAlign node = new DAlign((ins.reg() == Register.Pri) ? block.stack().pri() : block.stack().alt(), ins.number());
+					
+				block.stack().set((ins.reg() == Register.Pri) ? Register.Pri : Register.Alt, node);
 				block.add(node);
 				break;
 			}
@@ -790,15 +800,6 @@ public class NodeBuilder {
 						block.stack().pop();
 				}
 				block.add(new DLabel(ins.pc()));
-				break;
-			}
-			
-			case Align: {
-				LAlign ins = (LAlign) uins;
-				if (ins.reg() == Register.Pri)
-					block.stack().set(Register.Pri, block.stack().alt());
-				else
-					block.stack().set(Register.Alt, block.stack().pri());
 				break;
 			}
 

--- a/src/main/java/lysis/nodes/NodeRewriter.java
+++ b/src/main/java/lysis/nodes/NodeRewriter.java
@@ -1,5 +1,6 @@
 package lysis.nodes;
 
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoundsCheck;
@@ -290,6 +291,10 @@ public class NodeRewriter extends NodeVisitor {
 		default:
 			throw new Exception("unknown spop");
 		}
+	}
+	
+	@Override
+	public void visit(DAlign check) {
 	}
 
 	private void rewriteBlock(NodeBlock block) throws Exception {

--- a/src/main/java/lysis/nodes/NodeType.java
+++ b/src/main/java/lysis/nodes/NodeType.java
@@ -1,5 +1,5 @@
 package lysis.nodes;
 
 public enum NodeType {
-	Sentinel, Constant, DeclareLocal, DeclareStatic, LocalRef, Jump, JumpCondition, SysReq, Binary, BoundsCheck, ArrayRef, Store, Load, Return, Global, String, Boolean, Float, Function, Character, Call, TempName, Phi, Unary, IncDec, Heap, MemCopy, InlineArray, Switch, GenArray, Label
+	Sentinel, Constant, DeclareLocal, DeclareStatic, LocalRef, Jump, JumpCondition, SysReq, Binary, BoundsCheck, ArrayRef, Store, Load, Return, Global, String, Boolean, Float, Function, Character, Call, TempName, Phi, Unary, IncDec, Heap, MemCopy, InlineArray, Switch, GenArray, Label, Align
 }

--- a/src/main/java/lysis/nodes/NodeVisitor.java
+++ b/src/main/java/lysis/nodes/NodeVisitor.java
@@ -1,5 +1,6 @@
 package lysis.nodes;
 
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoolean;
@@ -116,5 +117,8 @@ public abstract class NodeVisitor {
 	}
 
 	public void visit(DLabel gototarget) {
+	}
+	
+	public void visit(DAlign number) {
 	}
 }

--- a/src/main/java/lysis/nodes/types/DAlign.java
+++ b/src/main/java/lysis/nodes/types/DAlign.java
@@ -1,0 +1,33 @@
+package lysis.nodes.types;
+
+import lysis.nodes.NodeType;
+import lysis.nodes.NodeVisitor;
+
+public class DAlign extends DUnaryNode {
+
+	private long amount_;
+
+	public DAlign(DNode index, long amount) throws Exception {
+		super(index);
+		amount_ = amount;
+	}
+
+	public long amount() {
+		return amount_;
+	}
+
+	@Override
+	public NodeType type() {
+		return NodeType.Align;
+	}
+
+	@Override
+	public void accept(NodeVisitor visitor) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public boolean guard() {
+		return true;
+	}
+}

--- a/src/main/java/lysis/types/BackwardTypePropagation.java
+++ b/src/main/java/lysis/types/BackwardTypePropagation.java
@@ -15,6 +15,7 @@ import lysis.nodes.NodeGraph;
 import lysis.nodes.NodeList;
 import lysis.nodes.NodeType;
 import lysis.nodes.NodeVisitor;
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoolean;
@@ -400,5 +401,8 @@ public class BackwardTypePropagation extends NodeVisitor {
 		for (int i = 0; i < genarray.numOperands(); i++) {
 			genarray.getOperand(i).accept(this);
 		}
+	}
+	
+	public void visit(DAlign check) {
 	}
 }

--- a/src/main/java/lysis/types/ForwardTypePropagation.java
+++ b/src/main/java/lysis/types/ForwardTypePropagation.java
@@ -9,6 +9,7 @@ import lysis.nodes.NodeGraph;
 import lysis.nodes.NodeList;
 import lysis.nodes.NodeType;
 import lysis.nodes.NodeVisitor;
+import lysis.nodes.types.DAlign;
 import lysis.nodes.types.DArrayRef;
 import lysis.nodes.types.DBinary;
 import lysis.nodes.types.DBoundsCheck;
@@ -292,5 +293,9 @@ public class ForwardTypePropagation extends NodeVisitor {
 			assert (tu != null);
 			genarray.addType(new TypeUnit(tu));
 		}
+	}
+	
+	@Override
+	public void visit(DAlign node) {
 	}
 }


### PR DESCRIPTION
Test plugin:
```
/* Sublime AMXX Editor v4.2 */

#include <amxmodx>
#include <amxmisc>

#pragma compress 1

#define PLUGIN  "Plugin"
#define VERSION "1.0"
#define AUTHOR  "Shadows Adi"

public plugin_init()
{
	#emit ALIGN.pri 28876 

	register_plugin(PLUGIN, VERSION, AUTHOR)
	new iDate
	date(iDate)
}
```

Output before:
```
/* ERROR PREPROCESSING! Unrecognized opcode: align_pri */
 function "plugin_init" (number 0)
new MaxClients;
new String:NULL_STRING[4];
new Float:NULL_VECTOR[3];

/* ERROR! Unrecognized opcode: align_pri */
 function "plugin_init" (number 0)
```

Output after:
```
 new MaxClients;
new String:NULL_STRING[4];
new Float:NULL_VECTOR[3];
public plugin_init()
{
	register_plugin("Plugin", "1.0", "Shadows Adi");
	new iDate;
	date(iDate, 0, 0);
	return 0;
}
```